### PR TITLE
change zookeeper package cause old one was deprecated

### DIFF
--- a/Election_test.go
+++ b/Election_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	zk "github.com/samuel/go-zookeeper/zk"
+	zk "github.com/go-zookeeper/zk"
 )
 
 // NOTE!!!!!

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This section provides an overview of the various phases of an election. The file
 Leader Election (LE) clients will have to import the following packages:
 
     import (
-    	"github.com/samuel/go-zookeeper/zk"
+    	"github.com/go-zookeeper/zk"
     	"github.com/Comcast/go-leaderelection"
     )
 
@@ -181,8 +181,8 @@ Candidates are always notified when an election's status changes. It is up to th
 
 # Prerequisites
 
-1. `go-leaderelection` uses `github.com/samuel/go-zookeeper/zk`.
-1. All tests require the availablility of a Zookeeper installation. `zkServer.sh` must be in the path. `Election_test.go` requires that Zookeeper be running. The integration tests control Zookeeper so Zookeeper should not be running when executing the integration tests.
+1. `go-leaderelection` uses `github.com/go-zookeeper/zk`.
+1. All tests require the availability of a Zookeeper installation. `zkServer.sh` must be in the path. `Election_test.go` requires that Zookeeper be running. The integration tests control Zookeeper so Zookeeper should not be running when executing the integration tests.
 
 Testing the package has additional prerequisites:
 

--- a/integrationtest/leader_crash_test/mock_worker.go
+++ b/integrationtest/leader_crash_test/mock_worker.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 
 	"golang.org/x/net/context"
 

--- a/integrationtest/zk_clientname.go
+++ b/integrationtest/zk_clientname.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/Comcast/go-leaderelection"
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 
 	"log"
 )

--- a/integrationtest/zk_deleteMissingElection.go
+++ b/integrationtest/zk_deleteMissingElection.go
@@ -24,8 +24,8 @@ import (
 
 	"os"
 
-	"github.com/samuel/go-zookeeper/zk"
 	"github.com/Comcast/go-leaderelection"
+	"github.com/go-zookeeper/zk"
 )
 
 type zkDeleteMissingElectionTest struct {

--- a/integrationtest/zk_followerresignation.go
+++ b/integrationtest/zk_followerresignation.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/Comcast/go-leaderelection"
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 // zkFollowerResignationTest is the struct that controls the test.

--- a/integrationtest/zk_happypath.go
+++ b/integrationtest/zk_happypath.go
@@ -26,7 +26,7 @@ import (
 	"os"
 
 	"github.com/Comcast/go-leaderelection"
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 // zkHappyPathTest is the struct that controls the test.

--- a/integrationtest/zk_leaderresignation.go
+++ b/integrationtest/zk_leaderresignation.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/Comcast/go-leaderelection"
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 // zkLeaderResignationTest is the struct that controls the test.

--- a/integrationtest/zktest_test.go
+++ b/integrationtest/zktest_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 
 	"github.com/Comcast/go-leaderelection"
 	"github.com/Comcast/goint"


### PR DESCRIPTION
Repository https://github.com/samuel/go-zookeeper, which go-leaderelection relies on, is no longer maintained.
They recommend using https://github.com/go-zookeeper/zk instead.

So, changed the zookeeper package.