### PR TITLE
change zookeeper package cause old one was deprecated

### DIFF
--- a/Election_test.go
+++ b/Election_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	zk "github.com/samuel/go-zookeeper/zk"
+	zk "github.com/go-zookeeper/zk"
 )
 
 // NOTE!!!!!

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This section provides an overview of the various phases of an election. The file
 Leader Election (LE) clients will have to import the following packages:
 
     import (
-    	"github.com/samuel/go-zookeeper/zk"
+    	"github.com/go-zookeeper/zk"
     	"github.com/Comcast/go-leaderelection"
     )
 
@@ -181,8 +181,8 @@ Candidates are always notified when an election's status changes. It is up to th
 
 # Prerequisites
 
-1. `go-leaderelection` uses `github.com/samuel/go-zookeeper/zk`.
-1. All tests require the availablility of a Zookeeper installation. `zkServer.sh` must be in the path. `Election_test.go` requires that Zookeeper be running. The integration tests control Zookeeper so Zookeeper should not be running when executing the integration tests.
+1. `go-leaderelection` uses `github.com/go-zookeeper/zk`.
+1. All tests require the availability of a Zookeeper installation. `zkServer.sh` must be in the path. `Election_test.go` requires that Zookeeper be running. The integration tests control Zookeeper so Zookeeper should not be running when executing the integration tests.
 
 Testing the package has additional prerequisites:
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/youngkin/go-leaderelection
+module github.com/Comcast/go-leaderelection
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,12 @@
+module github.com/youngkin/go-leaderelection
+
+go 1.15
+
+require (
+	github.com/Comcast/go-leaderelection v0.0.0-20181102191523-272fd9e2bddc
+	github.com/Comcast/goint v0.0.0-20160331154011-38be0f9824d5
+	github.com/go-zookeeper/zk v1.0.2
+	golang.org/x/net v0.0.0-20211208012354-db4efeb81f4b
+)
+
+replace github.com/Comcast/go-leaderelection => ../go-leaderelection

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/Comcast/go-leaderelection v0.0.0-20181102191523-272fd9e2bddc h1:d+UT+QyUT6hFKRZCYOSugx+evnm0jurImPyBZGUjxLo=
+github.com/Comcast/go-leaderelection v0.0.0-20181102191523-272fd9e2bddc/go.mod h1:i7z5KF7/zOF0Tzu/mQIyWPfdg5CxOixe1vh/mmgCcls=
+github.com/Comcast/goint v0.0.0-20160331154011-38be0f9824d5 h1:0CMIuBR1+jslJsSG95ea3YnYEWkjwMKmvTzty2+BukY=
+github.com/Comcast/goint v0.0.0-20160331154011-38be0f9824d5/go.mod h1:nrYhCL2GwfW8WrvxI9xQKjP5d1b5K9H4nDHnpEnEM3k=
+github.com/go-zookeeper/zk v1.0.2 h1:4mx0EYENAdX/B/rbunjlt5+4RTA/a9SMHBRuSKdGxPM=
+github.com/go-zookeeper/zk v1.0.2/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
+github.com/samuel/go-zookeeper v0.0.0-20201211165307-7117e9ea2414 h1:AJNDS0kP60X8wwWFvbLPwDuojxubj9pbfK7pjHw0vKg=
+github.com/samuel/go-zookeeper v0.0.0-20201211165307-7117e9ea2414/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
+golang.org/x/net v0.0.0-20211208012354-db4efeb81f4b h1:MWaHNqZy3KTpuTMAGvv+Kw+ylsEpmyJZizz1dqxnu28=
+golang.org/x/net v0.0.0-20211208012354-db4efeb81f4b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/integrationtest/leader_crash_test/mock_worker.go
+++ b/integrationtest/leader_crash_test/mock_worker.go
@@ -4,15 +4,12 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"time"
 
+	"github.com/Comcast/go-leaderelection"
 	"github.com/go-zookeeper/zk"
-
-	"golang.org/x/net/context"
-
-	"github.comcast.com/viper-cog/clog"
-	"github.comcast.com/viper-cog/goutil/leaderelection"
 )
 
 const (
@@ -33,8 +30,6 @@ func main() {
 		os.Exit(-1)
 	}
 
-	ctx := context.Background()
-
 	switch os.Args[1] {
 	case "leader":
 		expectToBeLeader = true
@@ -48,38 +43,37 @@ func main() {
 	zkConn, _, err := zk.Connect([]string{zkServerAddr}, heartBeatTimeout)
 
 	if err != nil {
-		clog.Errorf(clog.FuncStr()+"zkLeaderCrashTest: Error in zk.Connect (%s): %v",
+		log.Fatalf("zkLeaderCrashTest: Error in zk.Connect (%s): %v",
 			zkServerAddr, err)
-		os.Exit(-1)
 	}
 
 	currElection, err := leaderelection.NewElection(zkConn, electionNode, "myhostname")
 
 	if err != nil {
-		clog.Errorf(clog.FuncStr()+"zkLeaderCrashTest: Error in NewElection (%s): %v",
+		log.Fatalf("zkLeaderCrashTest: Error in NewElection (%s): %v",
 			electionNode, err)
 		os.Exit(-1)
 	}
 
 	done := make(chan struct{})
 	go func() {
-		currElection.ElectLeader(ctx)
+		currElection.ElectLeader()
 		done <- struct{}{}
 	}()
 	status := <-currElection.Status()
 	if status.Err != nil {
-		clog.Errorf(clog.FuncStr()+"zkLeaderCrashTest: Error in ElectLeader: %v", err)
+		log.Fatalf("zkLeaderCrashTest: Error in ElectLeader: %v", err)
 		os.Exit(-1)
 	}
 
 	if expectToBeLeader {
 		if status.Role != leaderelection.Leader {
-			clog.Errorf(clog.FuncStr() + "zkLeaderCrashTest: Expected to be leader but isn't")
+			log.Fatalf("zkLeaderCrashTest: Expected to be leader but isn't")
 			os.Exit(-1)
 		}
 	} else {
 		if status.Role != leaderelection.Follower {
-			clog.Errorf(clog.FuncStr() + "zkLeaderCrashTest: Expected to be follower but isn't")
+			log.Fatalf("zkLeaderCrashTest: Expected to be follower but isn't")
 			os.Exit(-1)
 		}
 	}
@@ -88,15 +82,13 @@ func main() {
 	for count := 0; count < 6; count++ {
 		time.Sleep(1 * time.Second)
 		if expectToBeLeader {
-			fmt.Println("leader: Working...")
-			clog.Infof(clog.FuncStr() + "leader: Working...")
+			log.Printf("main() - leader: Working...")
 		} else {
 
-			fmt.Println("follower: Waiting to become the leader...")
-			clog.Infof(clog.FuncStr() + "follower: Waiting to become the leader...")
+			log.Println("main() - follower: Waiting to become the leader...")
 			status := <-currElection.Status()
 			if status.Role != leaderelection.Leader {
-				clog.Errorf(clog.FuncStr()+"follower: Didn't become leader as expected! Got: %v",
+				log.Fatalf("follower: Didn't become leader as expected! Got: %v",
 					status)
 				os.Exit(-1)
 			}
@@ -104,7 +96,7 @@ func main() {
 			time.Sleep(1 * time.Second)
 
 			// Resign from the election
-			currElection.Resign(ctx)
+			currElection.Resign()
 			<-done
 			// This is the only time we return a success
 			os.Exit(0)

--- a/integrationtest/leader_crash_test/mock_worker.go
+++ b/integrationtest/leader_crash_test/mock_worker.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 
 	"golang.org/x/net/context"
 

--- a/integrationtest/removeZKNode.sh
+++ b/integrationtest/removeZKNode.sh
@@ -31,9 +31,9 @@ then
 	 exit 1
 fi
 
-OP="rmr $1"
+OP="deleteall $1"
 
-FOUND=`type -P zkCli.sh`
+FOUND=`which zkCli`
 if [ $? -eq 0 ]; then
 	 echo "Zookeper Client found at $FOUND"
 	 ZKCLI=$FOUND
@@ -41,7 +41,7 @@ if [ $? -eq 0 ]; then
 	 exit $?
 fi
 
-FOUND=`type -P zkcli`
+FOUND=`which zkcli`
 if [ $? -eq 0 ]; then
 	 echo "Zookeper Client found at $FOUND"
 	 ZKCLI=$FOUND

--- a/integrationtest/zk_clientname.go
+++ b/integrationtest/zk_clientname.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/Comcast/go-leaderelection"
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 
 	"log"
 )

--- a/integrationtest/zk_deleteMissingElection.go
+++ b/integrationtest/zk_deleteMissingElection.go
@@ -24,8 +24,8 @@ import (
 
 	"os"
 
-	"github.com/samuel/go-zookeeper/zk"
 	"github.com/Comcast/go-leaderelection"
+	"github.com/go-zookeeper/zk"
 )
 
 type zkDeleteMissingElectionTest struct {

--- a/integrationtest/zk_followerresignation.go
+++ b/integrationtest/zk_followerresignation.go
@@ -268,7 +268,7 @@ func electAndAssert(elector *leaderelection.Election, isExpectedToBeLeader bool)
 	s := <-elector.Status()
 
 	if s.Role != role {
-		return s, fmt.Errorf("Unexpected leadership status %s for candidate %s", s.Role, s.CandidateID)
+		return s, fmt.Errorf("Unexpected leadership status %d for candidate %s", s.Role, s.CandidateID)
 	}
 	return s, nil
 }

--- a/integrationtest/zk_followerresignation.go
+++ b/integrationtest/zk_followerresignation.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/Comcast/go-leaderelection"
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 // zkFollowerResignationTest is the struct that controls the test.

--- a/integrationtest/zk_happypath.go
+++ b/integrationtest/zk_happypath.go
@@ -26,7 +26,7 @@ import (
 	"os"
 
 	"github.com/Comcast/go-leaderelection"
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 // zkHappyPathTest is the struct that controls the test.

--- a/integrationtest/zk_leaderresignation.go
+++ b/integrationtest/zk_leaderresignation.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/Comcast/go-leaderelection"
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 )
 
 // zkLeaderResignationTest is the struct that controls the test.

--- a/integrationtest/zktest_test.go
+++ b/integrationtest/zktest_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 
 	"github.com/Comcast/go-leaderelection"
 	"github.com/Comcast/goint"

--- a/integrationtest/zookeeper.sh
+++ b/integrationtest/zookeeper.sh
@@ -40,7 +40,7 @@ case $1 in
 esac
 
 
-FOUND=`type -P zkServer.sh`
+FOUND=`which zkServer`
 if [ $? -eq 0 ]; then
 	 echo "Zookeper found at $FOUND"
 	 ZKSERVER=$FOUND
@@ -48,7 +48,7 @@ if [ $? -eq 0 ]; then
 	 exit $?
 fi
 
-FOUND=`type -P zkServer`
+FOUND=`which zkserver`
 if [ $? -eq 0 ]; then
 	 echo "Zookeper found at $FOUND"
 	 ZKSERVER=$FOUND


### PR DESCRIPTION
Performs the same update of the Zookeeper package as https://github.com/Comcast/go-leaderelection/pull/6, except I've signed the contribution agreement. Credit to @sangheee

----

Repository https://github.com/samuel/go-zookeeper, which go-leaderelection relies on, is no longer maintained.
They recommend using https://github.com/go-zookeeper/zk instead.

So, changed the zookeeper package.